### PR TITLE
Add minimal IssueTracker app

### DIFF
--- a/IssueTracker/Data/AppDbContext.cs
+++ b/IssueTracker/Data/AppDbContext.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace IssueTracker.Data;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+
+    public DbSet<Client> Clients => Set<Client>();
+    public DbSet<Project> Projects => Set<Project>();
+    public DbSet<Module> Modules => Set<Module>();
+    public DbSet<SubModule> SubModules => Set<SubModule>();
+    public DbSet<Type> Types => Set<Type>();
+    public DbSet<Status> Statuses => Set<Status>();
+    public DbSet<AppUser> AppUsers => Set<AppUser>();
+    public DbSet<IssueTask> IssueTasks => Set<IssueTask>();
+}

--- a/IssueTracker/Data/Entities.cs
+++ b/IssueTracker/Data/Entities.cs
@@ -1,0 +1,80 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace IssueTracker.Data;
+
+public class Client
+{
+    public int ClientId { get; set; }
+    [Required, MaxLength(100)] public string Name { get; set; } = string.Empty;
+    public ICollection<Project> Projects { get; set; } = new List<Project>();
+}
+
+public class Project
+{
+    public int ProjectId { get; set; }
+    [Required, MaxLength(100)] public string Name { get; set; } = string.Empty;
+    public int ClientId { get; set; }
+    public Client? Client { get; set; }
+    public ICollection<Module> Modules { get; set; } = new List<Module>();
+}
+
+public class Module
+{
+    public int ModuleId { get; set; }
+    [Required, MaxLength(100)] public string Name { get; set; } = string.Empty;
+    public int ProjectId { get; set; }
+    public Project? Project { get; set; }
+    public ICollection<SubModule> SubModules { get; set; } = new List<SubModule>();
+}
+
+public class SubModule
+{
+    public int SubModuleId { get; set; }
+    [Required, MaxLength(100)] public string Name { get; set; } = string.Empty;
+    public int ModuleId { get; set; }
+    public Module? Module { get; set; }
+}
+
+public class Type
+{
+    public int TypeId { get; set; }
+    [Required, MaxLength(100)] public string Name { get; set; } = string.Empty;
+}
+
+public class Status
+{
+    public int StatusId { get; set; }
+    [Required, MaxLength(100)] public string Name { get; set; } = string.Empty;
+}
+
+public class AppUser
+{
+    public int AppUserId { get; set; }
+    [Required, MaxLength(100)] public string Name { get; set; } = string.Empty;
+}
+
+public class IssueTask
+{
+    public int IssueTaskId { get; set; }
+    [Required, MaxLength(30)] public string IssueNo { get; set; } = string.Empty;
+    public int ModuleId { get; set; }
+    public int SubModuleId { get; set; }
+    [Required, MaxLength(100)] public string FormPageName { get; set; } = string.Empty;
+    [Required, MaxLength(150)] public string IssueTitle { get; set; } = string.Empty;
+    [Required] public string Description { get; set; } = string.Empty;
+    public int StatusId { get; set; }
+    public int TypeId { get; set; }
+    [Column(TypeName="decimal(5,1)")] public decimal? EffortHr { get; set; }
+    [MaxLength(400)] public string? RemarkInternal { get; set; }
+    [MaxLength(400)] public string? RemarkClient { get; set; }
+    public int AssignedToId { get; set; }
+    public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
+    public DateTime? UpdatedUtc { get; set; }
+
+    public Module? Module { get; set; }
+    public SubModule? SubModule { get; set; }
+    public Status? Status { get; set; }
+    public Type? Type { get; set; }
+    public AppUser? AssignedTo { get; set; }
+}

--- a/IssueTracker/Data/SeedData.cs
+++ b/IssueTracker/Data/SeedData.cs
@@ -1,0 +1,41 @@
+namespace IssueTracker.Data;
+
+public static class SeedData
+{
+    public static void Initialize(AppDbContext db)
+    {
+        if (!db.AppUsers.Any())
+        {
+            db.AppUsers.AddRange(
+                new AppUser { Name = "admin" },
+                new AppUser { Name = "dev" }
+            );
+        }
+        if (!db.Clients.Any())
+        {
+            var client = new Client { Name = "DemoClient" };
+            var project = new Project { Name = "DemoProject", Client = client };
+            var module = new Module { Name = "Core", Project = project };
+            var sub = new SubModule { Name = "Feature", Module = module };
+            var type = new Type { Name = "Bug" };
+            var status = new Status { Name = "Open" };
+            db.AddRange(client, project, module, sub, type, status);
+            db.SaveChanges();
+            db.IssueTasks.Add(new IssueTask
+            {
+                IssueNo = "ISS-1",
+                ModuleId = module.ModuleId,
+                SubModuleId = sub.SubModuleId,
+                FormPageName = "Index",
+                IssueTitle = "Sample Issue",
+                Description = "Demo description",
+                StatusId = status.StatusId,
+                TypeId = type.TypeId,
+                AssignedToId = db.AppUsers.First().AppUserId,
+                EffortHr = 1,
+                CreatedUtc = DateTime.UtcNow
+            });
+        }
+        db.SaveChanges();
+    }
+}

--- a/IssueTracker/IssueTracker.csproj
+++ b/IssueTracker/IssueTracker.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/IssueTracker/Pages/Dashboard.cshtml
+++ b/IssueTracker/Pages/Dashboard.cshtml
@@ -1,0 +1,21 @@
+@page
+@model DashboardModel
+@{
+    ViewData["Title"] = "Dashboard";
+}
+<partial name="Shared/_FilterBar" />
+<div class="row mb-3">
+    <partial name="Shared/_KpiCard" model="Model.KpiTotal" />
+    <partial name="Shared/_KpiCard" model="Model.KpiPending" />
+    <partial name="Shared/_KpiCard" model="Model.KpiOverdue" />
+    <partial name="Shared/_KpiCard" model="Model.KpiEffort" />
+</div>
+<table class="table table-striped">
+    <thead><tr><th>No</th><th>Title</th><th>Status</th></tr></thead>
+    <tbody>
+    @foreach (var i in Model.Issues)
+    {
+        <partial name="Shared/_IssueRow" model="i" />
+    }
+    </tbody>
+</table>

--- a/IssueTracker/Pages/Dashboard.cshtml.cs
+++ b/IssueTracker/Pages/Dashboard.cshtml.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using IssueTracker.Data;
+
+[Authorize]
+public class DashboardModel : PageModel
+{
+    private readonly AppDbContext _db;
+    public DashboardModel(AppDbContext db) => _db = db;
+
+    public IList<IssueTask> Issues { get; set; } = new List<IssueTask>();
+    public (string Title, decimal Value) KpiTotal = ("Total",0);
+    public (string Title, decimal Value) KpiPending = ("Pending",0);
+    public (string Title, decimal Value) KpiOverdue = ("Overdue",0);
+    public (string Title, decimal Value) KpiEffort = ("Effort (h)",0);
+
+    public async Task OnGetAsync()
+    {
+        Issues = await _db.IssueTasks.Include(i=>i.Status).ToListAsync();
+        KpiTotal.Value = Issues.Count;
+        KpiPending.Value = Issues.Count(i=>i.Status!.Name=="Open");
+        KpiOverdue.Value = Issues.Count(i=>i.UpdatedUtc.HasValue==false);
+        KpiEffort.Value = Issues.Sum(i=>i.EffortHr??0);
+
+        ViewBag.Clients = await _db.Clients.ToListAsync();
+        ViewBag.Projects = await _db.Projects.ToListAsync();
+        ViewBag.Modules = await _db.Modules.ToListAsync();
+        ViewBag.SubModules = await _db.SubModules.ToListAsync();
+    }
+}

--- a/IssueTracker/Pages/Index.cshtml
+++ b/IssueTracker/Pages/Index.cshtml
@@ -1,0 +1,7 @@
+@page
+@model PageModel
+@{
+    ViewData["Title"] = "Home";
+}
+<h2>Welcome to IssueTracker</h2>
+<a asp-page="/Dashboard">Go to Dashboard</a>

--- a/IssueTracker/Pages/Index.cshtml.cs
+++ b/IssueTracker/Pages/Index.cshtml.cs
@@ -1,0 +1,6 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+public class IndexModel : PageModel
+{
+    public void OnGet() {}
+}

--- a/IssueTracker/Pages/Issues/Create.cshtml
+++ b/IssueTracker/Pages/Issues/Create.cshtml
@@ -1,0 +1,57 @@
+@page
+@model Issues_CreateModel
+@{
+    ViewData["Title"] = "New Issue";
+}
+<h2>Create Issue</h2>
+<form method="post">
+    <div class="mb-3">
+        <label asp-for="Issue.IssueNo" class="form-label"></label>
+        <input asp-for="Issue.IssueNo" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="Issue.ModuleId" class="form-label"></label>
+        <select asp-for="Issue.ModuleId" class="form-select" asp-items="@(new SelectList(Model.Modules,"ModuleId","Name"))"></select>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Issue.SubModuleId" class="form-label"></label>
+        <select asp-for="Issue.SubModuleId" class="form-select" asp-items="@(new SelectList(Model.SubModules,"SubModuleId","Name"))"></select>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Issue.FormPageName" class="form-label"></label>
+        <input asp-for="Issue.FormPageName" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="Issue.IssueTitle" class="form-label"></label>
+        <input asp-for="Issue.IssueTitle" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="Issue.Description" class="form-label"></label>
+        <textarea asp-for="Issue.Description" class="form-control"></textarea>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Issue.StatusId" class="form-label"></label>
+        <select asp-for="Issue.StatusId" class="form-select" asp-items="@(new SelectList(Model.Statuses,"StatusId","Name"))"></select>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Issue.TypeId" class="form-label"></label>
+        <select asp-for="Issue.TypeId" class="form-select" asp-items="@(new SelectList(Model.Types,"TypeId","Name"))"></select>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Issue.EffortHr" class="form-label"></label>
+        <input asp-for="Issue.EffortHr" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="Issue.RemarkInternal" class="form-label"></label>
+        <input asp-for="Issue.RemarkInternal" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="Issue.RemarkClient" class="form-label"></label>
+        <input asp-for="Issue.RemarkClient" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="Issue.AssignedToId" class="form-label"></label>
+        <select asp-for="Issue.AssignedToId" class="form-select" asp-items="@(new SelectList(Model.Users,"AppUserId","Name"))"></select>
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+</form>

--- a/IssueTracker/Pages/Issues/Create.cshtml.cs
+++ b/IssueTracker/Pages/Issues/Create.cshtml.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using IssueTracker.Data;
+
+[Authorize]
+public class Issues_CreateModel : PageModel
+{
+    private readonly AppDbContext _db;
+    public Issues_CreateModel(AppDbContext db) => _db = db;
+
+    [BindProperty]
+    public IssueTask Issue { get; set; } = new();
+    public List<Module> Modules { get; set; } = new();
+    public List<SubModule> SubModules { get; set; } = new();
+    public List<Status> Statuses { get; set; } = new();
+    public List<Type> Types { get; set; } = new();
+    public List<AppUser> Users { get; set; } = new();
+
+    public async Task OnGetAsync()
+    {
+        Modules = await _db.Modules.ToListAsync();
+        SubModules = await _db.SubModules.ToListAsync();
+        Statuses = await _db.Statuses.ToListAsync();
+        Types = await _db.Types.ToListAsync();
+        Users = await _db.AppUsers.ToListAsync();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        Issue.CreatedUtc = DateTime.UtcNow;
+        _db.IssueTasks.Add(Issue);
+        await _db.SaveChangesAsync();
+        return RedirectToPage("Index");
+    }
+}

--- a/IssueTracker/Pages/Issues/Delete.cshtml
+++ b/IssueTracker/Pages/Issues/Delete.cshtml
@@ -1,0 +1,10 @@
+@page "{id:int}"
+@model Issues_DeleteModel
+<div class="alert alert-danger">
+    Are you sure you want to delete this issue?
+    <form method="post">
+        <input type="hidden" asp-for="Issue.IssueTaskId" />
+        <button class="btn btn-danger">Delete</button>
+        <a asp-page="Index" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>

--- a/IssueTracker/Pages/Issues/Delete.cshtml.cs
+++ b/IssueTracker/Pages/Issues/Delete.cshtml.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using IssueTracker.Data;
+
+[Authorize]
+public class Issues_DeleteModel : PageModel
+{
+    private readonly AppDbContext _db;
+    public Issues_DeleteModel(AppDbContext db) => _db = db;
+
+    [BindProperty]
+    public IssueTask Issue { get; set; } = new();
+
+    public async Task<IActionResult> OnGetAsync(int id)
+    {
+        var issue = await _db.IssueTasks.FindAsync(id);
+        if (issue == null) return RedirectToPage("Index");
+        Issue = issue;
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        var issue = await _db.IssueTasks.FindAsync(Issue.IssueTaskId);
+        if (issue != null)
+        {
+            _db.IssueTasks.Remove(issue);
+            await _db.SaveChangesAsync();
+        }
+        return RedirectToPage("Index");
+    }
+}

--- a/IssueTracker/Pages/Issues/Edit.cshtml
+++ b/IssueTracker/Pages/Issues/Edit.cshtml
@@ -1,0 +1,18 @@
+@page "{id:int}"
+@model Issues_EditModel
+@{
+    ViewData["Title"] = "Edit Issue";
+}
+<h2>Edit Issue</h2>
+<form method="post">
+    <input type="hidden" asp-for="Issue.IssueTaskId" />
+    <div class="mb-3">
+        <label asp-for="Issue.IssueTitle" class="form-label"></label>
+        <input asp-for="Issue.IssueTitle" class="form-control" />
+    </div>
+    <div class="mb-3">
+        <label asp-for="Issue.Description" class="form-label"></label>
+        <textarea asp-for="Issue.Description" class="form-control"></textarea>
+    </div>
+    <button class="btn btn-primary">Save</button>
+</form>

--- a/IssueTracker/Pages/Issues/Edit.cshtml.cs
+++ b/IssueTracker/Pages/Issues/Edit.cshtml.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using IssueTracker.Data;
+
+[Authorize]
+public class Issues_EditModel : PageModel
+{
+    private readonly AppDbContext _db;
+    public Issues_EditModel(AppDbContext db) => _db = db;
+
+    [BindProperty]
+    public IssueTask Issue { get; set; } = new();
+
+    public async Task<IActionResult> OnGetAsync(int id)
+    {
+        var issue = await _db.IssueTasks.FindAsync(id);
+        if (issue == null) return RedirectToPage("Index");
+        Issue = issue;
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        var existing = await _db.IssueTasks.FindAsync(Issue.IssueTaskId);
+        if (existing == null) return RedirectToPage("Index");
+        existing.IssueTitle = Issue.IssueTitle;
+        existing.Description = Issue.Description;
+        existing.UpdatedUtc = DateTime.UtcNow;
+        await _db.SaveChangesAsync();
+        return RedirectToPage("Index");
+    }
+}

--- a/IssueTracker/Pages/Issues/Index.cshtml
+++ b/IssueTracker/Pages/Issues/Index.cshtml
@@ -1,0 +1,16 @@
+@page
+@model Issues_IndexModel
+@{
+    ViewData["Title"] = "Issues";
+}
+<partial name="../Shared/_FilterBar" />
+<a asp-page="Create" class="btn btn-primary mb-2">New Issue</a>
+<table class="table table-bordered">
+    <thead><tr><th>No</th><th>Title</th><th>Status</th><th></th></tr></thead>
+    <tbody>
+    @foreach (var i in Model.Issues)
+    {
+        <partial name="../Shared/_IssueRow" model="i" />
+    }
+    </tbody>
+</table>

--- a/IssueTracker/Pages/Issues/Index.cshtml.cs
+++ b/IssueTracker/Pages/Issues/Index.cshtml.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using IssueTracker.Data;
+
+[Authorize]
+public class Issues_IndexModel : PageModel
+{
+    private readonly AppDbContext _db;
+    public Issues_IndexModel(AppDbContext db) => _db = db;
+
+    public IList<IssueTask> Issues { get; set; } = new List<IssueTask>();
+
+    public async Task OnGetAsync()
+    {
+        Issues = await _db.IssueTasks.Include(i=>i.Status).ToListAsync();
+        ViewBag.Clients = await _db.Clients.ToListAsync();
+        ViewBag.Projects = await _db.Projects.ToListAsync();
+        ViewBag.Modules = await _db.Modules.ToListAsync();
+        ViewBag.SubModules = await _db.SubModules.ToListAsync();
+    }
+}

--- a/IssueTracker/Pages/Login.cshtml
+++ b/IssueTracker/Pages/Login.cshtml
@@ -1,0 +1,21 @@
+@page
+@model LoginModel
+@{
+    Layout = "~/Pages/Shared/_Layout.cshtml";
+}
+<div class="row justify-content-center mt-5">
+    <div class="col-4">
+        <h2>Login</h2>
+        <form method="post">
+            <div class="mb-3">
+                <label asp-for="Input.Username" class="form-label"></label>
+                <input asp-for="Input.Username" class="form-control" />
+            </div>
+            <div class="mb-3">
+                <label asp-for="Input.Password" class="form-label"></label>
+                <input asp-for="Input.Password" type="password" class="form-control" />
+            </div>
+            <button type="submit" class="btn btn-primary">Login</button>
+        </form>
+    </div>
+</div>

--- a/IssueTracker/Pages/Login.cshtml.cs
+++ b/IssueTracker/Pages/Login.cshtml.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Security.Claims;
+using IssueTracker.Services;
+
+public class LoginModel : PageModel
+{
+    private readonly UserService _users;
+    public LoginModel(UserService users) => _users = users;
+
+    [BindProperty]
+    public Credential Input { get; set; } = new();
+
+    public record Credential
+    {
+        public string Username { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+    }
+
+    public void OnGet() { }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        var user = _users.Validate(Input.Username, Input.Password);
+        if (user == null) return Page();
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.Name, user.Username),
+            new Claim(ClaimTypes.NameIdentifier, user.Id.ToString())
+        };
+        var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+        await HttpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, new ClaimsPrincipal(identity));
+        return RedirectToPage("/Dashboard");
+    }
+}

--- a/IssueTracker/Pages/Logout.cshtml
+++ b/IssueTracker/Pages/Logout.cshtml
@@ -1,0 +1,3 @@
+@page
+@model LogoutModel
+<form method="post"></form>

--- a/IssueTracker/Pages/Logout.cshtml.cs
+++ b/IssueTracker/Pages/Logout.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+public class LogoutModel : PageModel
+{
+    public async Task<IActionResult> OnPostAsync()
+    {
+        await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        return RedirectToPage("/Login");
+    }
+}

--- a/IssueTracker/Pages/Masters/Index.cshtml
+++ b/IssueTracker/Pages/Masters/Index.cshtml
@@ -1,0 +1,18 @@
+@page "{type?}"
+@model Masters_IndexModel
+@{
+    ViewData["Title"] = $"{Model.Type} Master";
+}
+<h2>@ViewData["Title"]</h2>
+<form method="post" class="mb-3">
+    <div class="input-group">
+        <input asp-for="NewItem" class="form-control" />
+        <button class="btn btn-primary">Add</button>
+    </div>
+</form>
+<table class="table">
+@foreach (var item in Model.Items)
+{
+    <tr><td>@item</td></tr>
+}
+</table>

--- a/IssueTracker/Pages/Masters/Index.cshtml.cs
+++ b/IssueTracker/Pages/Masters/Index.cshtml.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using IssueTracker.Data;
+
+[Authorize]
+public class Masters_IndexModel : PageModel
+{
+    private readonly AppDbContext _db;
+    public Masters_IndexModel(AppDbContext db) => _db = db;
+
+    [BindProperty(SupportsGet = true)] public string Type { get; set; } = string.Empty;
+    [BindProperty] public string NewItem { get; set; } = string.Empty;
+    public List<string> Items { get; set; } = new();
+
+    public async Task OnGetAsync()
+    {
+        Items = await GetSet().Select(e => EF.Property<string>(e, "Name")).ToListAsync();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        var set = GetSet();
+        var entity = Activator.CreateInstance(set.EntityType.ClrType)!;
+        set.EntityType.FindProperty("Name")!.PropertyInfo!.SetValue(entity, NewItem);
+        set.Add(entity);
+        await _db.SaveChangesAsync();
+        return RedirectToPage(new { type = Type });
+    }
+
+    private DbSet<dynamic> GetSet() => Type.ToLower() switch
+    {
+        "client" => (DbSet<dynamic>)_db.Clients,
+        "project" => _db.Projects,
+        "module" => _db.Modules,
+        "submodule" => _db.SubModules,
+        "type" => _db.Types,
+        "status" => _db.Statuses,
+        "user" => _db.AppUsers,
+        _ => _db.Clients
+    };
+}

--- a/IssueTracker/Pages/MyTasks.cshtml
+++ b/IssueTracker/Pages/MyTasks.cshtml
@@ -1,0 +1,31 @@
+@page "/MyTasks/{date?}"
+@model MyTasksModel
+@{
+    ViewData["Title"] = "My Tasks";
+}
+<h2>My Tasks for @Model.Date.ToShortDateString()</h2>
+<table class="table">
+@foreach (var t in Model.Tasks)
+{
+    <tr>
+        <td>@t.IssueTitle</td>
+        <td>
+            <select class="form-select status" data-id="@t.IssueTaskId">
+            @foreach (var s in Model.Statuses)
+            {
+                <option value="@s.StatusId" selected="@(s.StatusId==t.StatusId)">@s.Name</option>
+            }
+            </select>
+        </td>
+    </tr>
+}
+</table>
+@section Scripts{
+<script>
+$(function(){
+    $('.status').change(function(){
+        $.post('/MyTasks/UpdateStatus',{id:$(this).data('id'),statusId:$(this).val()});
+    });
+});
+</script>
+}

--- a/IssueTracker/Pages/MyTasks.cshtml.cs
+++ b/IssueTracker/Pages/MyTasks.cshtml.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using IssueTracker.Data;
+
+[Authorize]
+public class MyTasksModel : PageModel
+{
+    private readonly AppDbContext _db;
+    public MyTasksModel(AppDbContext db) => _db = db;
+
+    [BindProperty(SupportsGet = true)] public DateTime Date { get; set; } = DateTime.Today;
+    public List<IssueTask> Tasks { get; set; } = new();
+    public List<Status> Statuses { get; set; } = new();
+
+    public async Task OnGetAsync()
+    {
+        var userId = int.Parse(User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)!.Value);
+        Tasks = await _db.IssueTasks.Include(t=>t.Status)
+            .Where(t=>t.AssignedToId==userId && t.CreatedUtc.Date==Date.Date)
+            .ToListAsync();
+        Statuses = await _db.Statuses.ToListAsync();
+    }
+}

--- a/IssueTracker/Pages/Shared/_FilterBar.cshtml
+++ b/IssueTracker/Pages/Shared/_FilterBar.cshtml
@@ -1,0 +1,22 @@
+<form class="row g-2 mb-3" method="get">
+    <div class="col">
+        <select class="form-select" name="clientId" asp-items="@(new SelectList(ViewBag.Clients,"ClientId","Name"))" onchange="this.form.submit()">
+            <option value="">Client</option>
+        </select>
+    </div>
+    <div class="col">
+        <select class="form-select" name="projectId" asp-items="@(new SelectList(ViewBag.Projects,"ProjectId","Name"))" onchange="this.form.submit()">
+            <option value="">Project</option>
+        </select>
+    </div>
+    <div class="col">
+        <select class="form-select" name="moduleId" asp-items="@(new SelectList(ViewBag.Modules,"ModuleId","Name"))" onchange="this.form.submit()">
+            <option value="">Module</option>
+        </select>
+    </div>
+    <div class="col">
+        <select class="form-select" name="subModuleId" asp-items="@(new SelectList(ViewBag.SubModules,"SubModuleId","Name"))" onchange="this.form.submit()">
+            <option value="">SubModule</option>
+        </select>
+    </div>
+</form>

--- a/IssueTracker/Pages/Shared/_IssueRow.cshtml
+++ b/IssueTracker/Pages/Shared/_IssueRow.cshtml
@@ -1,0 +1,10 @@
+@model IssueTracker.Data.IssueTask
+<tr>
+    <td>@Model.IssueNo</td>
+    <td>@Model.IssueTitle</td>
+    <td>@Model.Status?.Name</td>
+    <td>
+        <a asp-page="Edit" asp-route-id="@Model.IssueTaskId" class="btn btn-sm btn-secondary">Edit</a>
+        <a asp-page="Delete" asp-route-id="@Model.IssueTaskId" class="btn btn-sm btn-danger">Del</a>
+    </td>
+</tr>

--- a/IssueTracker/Pages/Shared/_KpiCard.cshtml
+++ b/IssueTracker/Pages/Shared/_KpiCard.cshtml
@@ -1,0 +1,9 @@
+@model (string Title, decimal Value)
+<div class="col">
+    <div class="card text-center">
+        <div class="card-body">
+            <h5 class="card-title">@Model.Title</h5>
+            <p class="display-6">@Model.Value</p>
+        </div>
+    </div>
+</div>

--- a/IssueTracker/Pages/Shared/_Layout.cshtml
+++ b/IssueTracker/Pages/Shared/_Layout.cshtml
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - IssueTracker</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
+</head>
+<body>
+    <header>
+        <nav class="navbar navbar-expand-sm navbar-light bg-light mb-3">
+            <div class="container">
+                <a class="navbar-brand" asp-page="/Dashboard">IssueTracker</a>
+                <div class="collapse navbar-collapse">
+                    <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                        <li class="nav-item"><a class="nav-link" asp-page="/Dashboard">Dashboard</a></li>
+                        <li class="nav-item"><a class="nav-link" asp-page="/Issues/Index">Issues</a></li>
+                        <li class="nav-item"><a class="nav-link" asp-page="/Masters/Index" asp-route-type="client">Masters</a></li>
+                    </ul>
+                    <ul class="navbar-nav">
+                        @if (User.Identity?.IsAuthenticated ?? false)
+                        {
+                            <li class="nav-item"><a class="nav-link" asp-page="/MyTasks" asp-route-date="@DateTime.Today.ToString("yyyy-MM-dd")">My Day</a></li>
+                            <li class="nav-item">
+                                <form method="post" asp-page="/Logout"><button class="btn btn-link nav-link" type="submit">Logout</button></form>
+                            </li>
+                        }
+                        else
+                        {
+                            <li class="nav-item"><a class="nav-link" asp-page="/Login">Login</a></li>
+                        }
+                    </ul>
+                </div>
+            </div>
+        </nav>
+    </header>
+    <div class="container">
+        @RenderBody()
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    @await RenderSectionAsync("Scripts", false)
+</body>
+</html>

--- a/IssueTracker/Pages/_ViewImports.cshtml
+++ b/IssueTracker/Pages/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+@using IssueTracker
+@using IssueTracker.Data
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/IssueTracker/Pages/_ViewStart.cshtml
+++ b/IssueTracker/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}

--- a/IssueTracker/Program.cs
+++ b/IssueTracker/Program.cs
@@ -1,0 +1,55 @@
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.EntityFrameworkCore;
+using IssueTracker.Data;
+using IssueTracker.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages(options =>
+{
+    options.Conventions.AuthorizeFolder("/");
+    options.Conventions.AllowAnonymousToPage("/Login");
+});
+
+builder.Services.AddDbContext<AppDbContext>(opt =>
+    opt.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie(o => o.LoginPath = "/Login");
+
+builder.Services.AddScoped<UserService>();
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseStaticFiles();
+app.UseRouting();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    db.Database.EnsureCreated();
+    SeedData.Initialize(db);
+}
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapRazorPages();
+
+app.MapPost("/MyTasks/UpdateStatus", async (AppDbContext db, int id, int statusId) =>
+{
+    var issue = await db.IssueTasks.FindAsync(id);
+    if (issue == null) return Results.NotFound();
+    issue.StatusId = statusId;
+    issue.UpdatedUtc = DateTime.UtcNow;
+    await db.SaveChangesAsync();
+    return Results.Ok();
+});
+
+app.Run();

--- a/IssueTracker/Services/UserService.cs
+++ b/IssueTracker/Services/UserService.cs
@@ -1,0 +1,15 @@
+namespace IssueTracker.Services;
+
+public record AppUserCred(int Id, string Username, string Password);
+
+public class UserService
+{
+    private readonly List<AppUserCred> _users = new()
+    {
+        new AppUserCred(1, "admin", "password"),
+        new AppUserCred(2, "dev", "password")
+    };
+
+    public AppUserCred? Validate(string username, string password)
+        => _users.FirstOrDefault(u => u.Username == username && u.Password == password);
+}

--- a/IssueTracker/appsettings.json
+++ b/IssueTracker/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=IssueTrackerDb;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- implement minimal IssueTracker web app
- add DB context, entities and seed data
- scaffold Razor Pages for issues, dashboard, masters and login
- include simple authentication service and layout

## Testing
- `dotnet build IssueTracker/IssueTracker.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859201cecac8329bd033e106c5b5c76